### PR TITLE
Multiple changes to use pebble query as db and fixes so ElasticBLAST will run

### DIFF
--- a/tools/workflow.sh
+++ b/tools/workflow.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+# call with two variables, example:
+# ./workflow.sh NC_024907 gs://pss4-madden/RESULTS/CARIBOU2
+# First option is the accession of the sequence for the pebble search
+# Second option is the path to your results bucket, which should be empty (or elastic-blast will refuse to 
+# overwrite old results)
+
 set -euo pipefail
 shopt -s nullglob
 
@@ -10,11 +16,11 @@ genbank="${1%.fa}"
 ##############################################################################
 # Configuration
 # Documentation on results: https://blast.ncbi.nlm.nih.gov/doc/elastic-blast/configuration.html#results
-results_bucket=${1:-"gs://psss-team4/test-results-$USER"}
+results_bucket=${2:-"gs://psss-team4/test-results-$USER"}
 export ELB_RESULTS=$results_bucket
 
 pebble_search_host=34.138.27.177
-blastdb_bucket=gs://psss-team4
+blastdb_bucket="gs://psss-team4/DB"
 
 
 CFG=`mktemp -t $(basename -s .sh $0)-XXXXXXX.ini`
@@ -28,7 +34,7 @@ curl "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nuccore&id=$g
 
 ##############################################################################
 # Pebble search
-/usr/local/bin/psearch_gcp --host $pebble_search_host $genbank_fa > $PEBBLES
+/usr/local/bin/psearch_gcp.sh --host $pebble_search_host $genbank_fa > $PEBBLES
 num_hits=`wc -l $PEBBLES | cut -f 1 -d ' '`
 if [ $num_hits -eq 0 ] ; then
     echo "Pebble search found no hits for $genbank"
@@ -40,10 +46,16 @@ fi
 
 
 ##############################################################################
-# TODO; Fetch fasta for the SRA hits, use these as ElasticBLAST target database
+# TODO; Fetch fasta for the SRA hits, 
+#EB_QUERIES=FIXME
+#EB_QUERIES="/home/madden/CARIBOUFECES/caribou.query-list"
 
-makeblastdb -dbtype nucl -in $sra_hits_fa -out $target_blastdb
-gsutil -qm cp $target_blastdb.* gs://${blastdb_bucket}/$target_blastdb
+##############################################################################
+#use the pebblesearch query as ElasticBLAST target database
+
+target_blastdb="$genbank"
+makeblastdb -dbtype nucl -in $genbank_fa -out $target_blastdb -parse_seqids
+gsutil -qm cp $target_blastdb.* ${blastdb_bucket}
 
 
 ##############################################################################
@@ -69,21 +81,25 @@ machine-type = n1-standard-32
 # Documentation: https://blast.ncbi.nlm.nih.gov/doc/elastic-blast/configuration.html#number-of-worker-nodes
 num-nodes = 10
 # Documentation: https://blast.ncbi.nlm.nih.gov/doc/elastic-blast/configuration.html#number-of-cpus
-num-cpus = FIXME
+# possbily best not to change.
+#num-cpus = FIXME
 
 [blast]
+# See documentation for setting batch-length at https://blast.ncbi.nlm.nih.gov/doc/elastic-blast/configuration.html#batch-length
+# Setting batch-len to a billion seems to work well for very small databases and large query sets
+batch-len = 1000000000
 # See documentation for supported programs: https://blast.ncbi.nlm.nih.gov/doc/elastic-blast/configuration.html#blast-program
 program = blastn
 # See documentation for using your own BLASTDB:
 # https://blast.ncbi.nlm.nih.gov/doc/elastic-blast/configuration.html#blast-database
 # https://blast.ncbi.nlm.nih.gov/doc/elastic-blast/tutorials/create-blastdb-metadata.html?highlight=create
-db = gs://${BLASTDB_BUCKET}/$target_blastdb
+db = ${blastdb_bucket}/$target_blastdb
 # See documentation for supported formats: https://blast.ncbi.nlm.nih.gov/doc/elastic-blast/configuration.html#query-sequence-data
-queries = FIXME
+queries = $EB_QUERIES
 # Documentation: https://blast.ncbi.nlm.nih.gov/doc/elastic-blast/configuration.html#memory-limit-for-blast-search 
-mem-limit = FIXME
+#mem-limit = FIXME
 # Documentation: https://blast.ncbi.nlm.nih.gov/doc/elastic-blast/configuration.html#blast-options
-options = -outfmt '7 std staxids'
+options = -evalue 0.0001 -outfmt 7 -mt_mode 1
 EOF
 
 elastic-blast submit --cfg $CFG


### PR DESCRIPTION
- Fixed parsing of variables
- Added comment on how to call
- Fixed some paths to gs:// buckets that did not work
- used pebble query to produce BLAST db
- set EB batch length to one billion (recommended here)
