### PR TITLE
Add policy to invoke get_fasta cloud function

### DIFF
--- a/tools/get-fasta/deploy.sh
+++ b/tools/get-fasta/deploy.sh
@@ -5,3 +5,5 @@ gcloud functions deploy get_fasta \
     --source . \
     --env-vars-file .env.yml \
     --stage-bucket psss-team4-victorlin
+
+gcloud functions set-iam-policy get_fasta iam-policy.json

--- a/tools/get-fasta/iam-policy.json
+++ b/tools/get-fasta/iam-policy.json
@@ -1,0 +1,8 @@
+{
+  "bindings": [
+    {
+      "members": ["allUsers"],
+      "role": "roles/cloudfunctions.invoker"
+    }
+  ]
+}


### PR DESCRIPTION
Note from [docs](https://cloud.google.com/iam/docs/reference/rest/v1/Policy):
> allUsers: A special identifier that represents anyone who is on the internet; with or without a Google account.

Ideally we should create/set IAM on the VM instance, but this is the easiest way to get things going.